### PR TITLE
TRIVIAL: use ESLint instead of TSLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+	"extends": "mrmlnc"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ npm-debug.log*
 node_modules/
 
 # Compiled and temporary files
+.eslintcache
 .tmp/
 out/
 

--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,10 @@
 .gitignore
 .vsts
 tsconfig.json
-tslint.json
+.eslintrc.json
+
+# Log & Cache files
+.eslintcache
 
 # Output files
 out/tests

--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
   "devDependencies": {
     "@types/mocha": "^5.2.7",
     "@types/node": "^8.10.53",
+    "eslint": "^6.5.1",
+    "eslint-config-mrmlnc": "^1.0.1",
     "mocha": "^6.2.0",
     "rimraf": "^3.0.0",
-    "tslint": "^5.19.0",
-    "tslint-config-mrmlnc": "^2.1.0",
     "typescript": "^3.6.2"
   },
   "dependencies": {},
   "scripts": {
     "clean": "rimraf out",
-    "lint": "tslint \"src/**/*.ts\" -p . -t stylish",
+    "lint": "eslint \"src/**/*.ts\" --cache",
     "compile": "tsc",
     "test": "mocha \"out/**/*.spec.js\" -s 0",
     "build": "npm run clean && npm run compile && npm run lint && npm test",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 
-import * as pkg from './index';
+import * as pkg from '.';
 
 describe('Package', () => {
 	describe('.sum', () => {

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,0 @@
-{
-	"extends": [
-		"tslint-config-mrmlnc"
-	]
-}


### PR DESCRIPTION
### What is the purpose of this pull request?

Upgrading the infrastructure of the repository. TSLint will be deprecated some time in 2019.

https://github.com/palantir/tslint/issues/4534